### PR TITLE
Simplify RPM package generation

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,67 +1,58 @@
 ARG alpine_version=latest
 
-FROM --platform=$BUILDPLATFORM alpine:$alpine_version AS builder
+FROM alpine:$alpine_version AS builder
 ARG llvm_version=18
 # add dependencies required for building crystal from source
 RUN apk add --update --no-cache \
     crystal shards \
     llvm${llvm_version}-dev llvm${llvm_version}-static \
-    zlib-static yaml-static libxml2-dev pcre2-dev libevent-static \
-    libffi-dev git g++ make automake libtool autoconf curl
-# Cross compile for target architecture
-ARG TARGETARCH
+    zlib-static yaml-static pcre2-dev zstd-static libxml2-static \
+    libffi-dev git g++ make automake libtool autoconf curl abuild asciidoctor
+
+WORKDIR /usr/src
+# Build libgc
+ARG gc_version=8.2.8
+ADD https://github.com/ivmai/bdwgc/archive/v${gc_version}.tar.gz bdwgc.tar.gz
+RUN tar zxf bdwgc.tar.gz && \
+    cd bdwgc-${gc_version} && \
+    source /usr/share/abuild/default.conf && \
+    ./autogen.sh && \
+    ./configure --disable-debug --disable-shared --enable-large-config --prefix=/usr && \
+    make -j$(nproc) && \
+    make install
+
 # Build crystal
-WORKDIR /usr/src/crystal
 ARG crystal_version=1.16.1
-RUN git clone --depth=1 --single-branch --branch=$crystal_version https://github.com/crystal-lang/crystal.git . && \
-  gzip -9 man/crystal.1 && \
-  mkdir .build && \
-  make crystal static=1 release=1 target=$TARGETARCH-alpine-linux-musl PREFIX=/usr FLAGS="--no-debug" | tail -1 > .build/crystal.sh
+ADD https://github.com/crystal-lang/crystal/archive/${crystal_version}.tar.gz crystal.tar.gz
+RUN tar zxf crystal.tar.gz && \
+    cd crystal-${crystal_version} && \
+    gzip -9 man/crystal.1 && \
+    source /usr/share/abuild/default.conf && \
+    make release=1 static=1 CRYSTAL_CONFIG_LIBRARY_PATH=/usr/lib/crystal LDFLAGS="$LDFLAGS -s -w" && \
+    make install PREFIX=/usr
+
 # Build shards
 WORKDIR /usr/src/shards
 ARG shards_version=0.19.1
-RUN git clone --depth=1 --single-branch --branch=v${shards_version} https://github.com/crystal-lang/shards.git . && \
-  gzip -9 man/shards.1 man/shard.yml.5 && \
-  make bin/shards static=1 release=1 FLAGS="--no-debug --cross-compile --target=$TARGETARCH-alpine-linux-musl" | tail -1 > bin/shards.sh
-
-# link on target platform
-FROM alpine:$alpine_version AS target-builder
-ARG llvm_version=18
-RUN apk add --update --no-cache \
-    llvm${llvm_version}-dev llvm${llvm_version}-static \
-    zstd-static zlib-static yaml-static libxml2-static pcre2-dev libevent-static \
-    libffi-dev git g++ make automake libtool autoconf curl
-# Build libgc
-WORKDIR /usr/src/libc
-ARG gc_version=8.2.8
-RUN git clone --depth=1 --single-branch --branch=v${gc_version} https://github.com/ivmai/bdwgc.git . && \
-  ./autogen.sh && \
-  ./configure --disable-debug --disable-shared --enable-large-config --prefix=/usr && \
-  make -j$(nproc) CFLAGS="-DNO_GETCONTEXT -pipe -fPIE -O3" && \
-  make install
-# Link crystal
-WORKDIR /usr/src/crystal
-COPY --from=builder /usr/src/crystal/Makefile .
-COPY --from=builder /usr/src/crystal/src/llvm/ext src/llvm/ext
-COPY --from=builder /usr/src/crystal/.build .build
-RUN sh -ex .build/crystal.sh && strip .build/crystal
-# Link shards
-WORKDIR /usr/src/shards
-COPY --from=builder /usr/src/shards/bin bin
-RUN sh -ex bin/shards.sh && strip bin/shards
+ADD https://github.com/crystal-lang/shards/archive/refs/tags/v${shards_version}.tar.gz shards.tar.gz
+RUN tar zxf shards.tar.gz && \
+    cd shards-${shards_version} && \
+    gzip -9 man/shards.1 man/shard.yml.5 && \
+    source /usr/share/abuild/default.conf && \
+    make release=1 static=1 CRYSTAL_CONFIG_LIBRARY_PATH=/usr/lib/crystal FLAGS="--link-flags=\"$LDFLAGS -s -w\"" && \
+    make install PREFIX=/usr
 
 # start from a clean image
 FROM alpine:$alpine_version
 # add dependencies commonly required for building crystal applications
-RUN apk add --update --no-cache musl-dev gcc pcre2-dev libevent-dev libevent-static openssl-dev openssl-libs-static libxml2-dev zlib-dev zlib-static git make yaml-dev libxml2-static gmp-dev xz-static yaml-static
+RUN apk add --update --no-cache musl-dev gcc pcre2-dev openssl-dev openssl-libs-static libxml2-dev zlib-dev zlib-static git make yaml-dev libxml2-static gmp-dev xz-static yaml-static
 # copy the binaries + stdlib + libgc from the build stage
-COPY --from=builder /usr/src/crystal/*.md /usr/share/doc/crystal/
-COPY --from=builder /usr/src/crystal/man/crystal.1.gz /usr/share/man/man1/
-COPY --from=builder /usr/src/shards/man/shards.1.gz /usr/share/man/man1/
-COPY --from=builder /usr/src/shards/man/shard.yml.5.gz /usr/share/man/man5/
-COPY --from=builder /usr/src/crystal/src /usr/share/crystal/src
-COPY --from=target-builder /usr/src/crystal/.build/crystal /usr/bin/
-COPY --from=target-builder /usr/src/shards/bin/shards /usr/bin/
-COPY --from=target-builder /usr/lib/libgc.a /usr/lib/crystal/
+COPY --from=builder /usr/share/man/man1/crystal.1.gz /usr/share/man/man1/
+COPY --from=builder /usr/share/man/man1/shards.1.gz /usr/share/man/man1/
+COPY --from=builder /usr/share/man/man5/shard.yml.5.gz /usr/share/man/man5/
+COPY --from=builder /usr/share/crystal /usr/share/crystal
+COPY --from=builder /usr/bin/crystal /usr/bin/
+COPY --from=builder /usr/bin/shards /usr/bin/
+COPY --from=builder /usr/lib/libgc.a /usr/lib/crystal/
 # set the default cmd, example usage: docker run --rm 84codes/crystal eval 'puts "hello world"'
 ENTRYPOINT ["/usr/bin/crystal"]

--- a/debian-static/Dockerfile
+++ b/debian-static/Dockerfile
@@ -48,9 +48,8 @@ ARG TARGETARCH
 RUN fpm -s dir -t deb -n crystal -v $(cat pkg/usr/share/crystal/src/VERSION) --iteration ${pkg_revision} -a ${TARGETARCH} \
   --url https://crystal-lang.org --maintainer "84codes <contact@84codes.com>" \
   --description "a general-purpose, object-oriented programming language" \
-  --depends gcc --depends pkg-config --depends libevent-dev \
-  --depends libpcre2-dev \
-  --depends libz-dev \
+  --depends gcc --depends pkg-config --depends libyaml \
+  --depends libpcre2-dev --depends libz-dev \
   --deb-recommends libssl-dev --deb-recommends libxml2-dev \
   --deb-recommends libgmp-dev --deb-recommends libyaml-dev \
   --deb-recommends git \

--- a/debian-static/Dockerfile
+++ b/debian-static/Dockerfile
@@ -48,7 +48,7 @@ ARG TARGETARCH
 RUN fpm -s dir -t deb -n crystal -v $(cat pkg/usr/share/crystal/src/VERSION) --iteration ${pkg_revision} -a ${TARGETARCH} \
   --url https://crystal-lang.org --maintainer "84codes <contact@84codes.com>" \
   --description "a general-purpose, object-oriented programming language" \
-  --depends gcc --depends pkg-config --depends libyaml \
+  --depends gcc --depends pkg-config \
   --depends libpcre2-dev --depends libz-dev \
   --deb-recommends libssl-dev --deb-recommends libxml2-dev \
   --deb-recommends libgmp-dev --deb-recommends libyaml-dev \

--- a/debian/debian/control
+++ b/debian/debian/control
@@ -6,7 +6,7 @@ Homepage: https://crystal-lang.org
 
 Package: crystal
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, gcc, pkg-config, libpcre2-dev, libz-dev, libyaml
+Depends: ${misc:Depends}, ${shlibs:Depends}, gcc, pkg-config, libpcre2-dev, libz-dev
 Recommends: libssl-dev, libxml2-dev, libgmp-dev, libyaml-dev, git
 Description: a general-purpose, object-oriented programming language
  Crystal is a programming language with a syntax similar to Ruby but

--- a/debian/debian/control
+++ b/debian/debian/control
@@ -6,7 +6,7 @@ Homepage: https://crystal-lang.org
 
 Package: crystal
 Architecture: any
-Depends: gcc, pkg-config, libpcre2-dev, libz-dev, libffi-dev, ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}, gcc, pkg-config, libpcre2-dev, libz-dev, libyaml
 Recommends: libssl-dev, libxml2-dev, libgmp-dev, libyaml-dev, git
 Description: a general-purpose, object-oriented programming language
  Crystal is a programming language with a syntax similar to Ruby but

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -23,14 +23,17 @@ COPY --from=alpine /usr/share/crystal /usr/share/crystal
 # Setup RPM build environment
 RUN rpmdev-setuptree
 
-# use rpmbuild to build RPM package
 WORKDIR /root/rpmbuild
+# use rpmbuild to build RPM package
 COPY crystal.spec /root/rpmbuild/SPECS/
 
 ARG crystal_version=1.16.1
-ARG gc_version=8.2.8
 ARG shards_version=0.19.1
 ARG pkg_revision=1
+
+# Download sources
+ADD https://github.com/crystal-lang/crystal/archive/${crystal_version}.tar.gz /root/rpmbuild/SOURCES/crystal.tar.gz
+ADD https://github.com/crystal-lang/shards/archive/refs/tags/v${shards_version}.tar.gz /root/rpmbuild/SOURCES/shards.tar.gz
 
 # Build the RPM package
 RUN rpmbuild -bb SPECS/crystal.spec \

--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -7,13 +7,10 @@ FROM 84codes/crystal:latest-alpine AS alpine
 FROM $base_image:$base_image_tag AS builder
 # add dependencies required for building crystal from source
 RUN dnf install -y --nodocs --repo=fedora,updates \
-        git gcc gcc-c++ make gc-devel \
-        llvm-devel \
-        pcre2-devel libxml2-devel libyaml-devel libffi-devel \
-        openssl-devel zlib-devel gmp-devel autoconf automake libtool \
-        rpm-build rpmdevtools && \
+        git gcc gcc-c++ make gc-devel llvm-devel \
+        pcre2-devel libyaml-devel libffi-devel \
+        zlib-devel rpm-build rpmdevtools && \
     dnf clean all
-RUN git config --global advice.detachedHead false
 
 # Use static compiler to compile crystal
 COPY --from=alpine /usr/bin/shards /usr/bin/
@@ -23,8 +20,8 @@ COPY --from=alpine /usr/share/crystal /usr/share/crystal
 # Setup RPM build environment
 RUN rpmdev-setuptree
 
-WORKDIR /root/rpmbuild
 # use rpmbuild to build RPM package
+WORKDIR /root/rpmbuild
 COPY crystal.spec /root/rpmbuild/SPECS/
 
 ARG crystal_version=1.16.1
@@ -38,8 +35,8 @@ ADD https://github.com/crystal-lang/shards/archive/refs/tags/v${shards_version}.
 # Build the RPM package
 RUN rpmbuild -bb SPECS/crystal.spec \
     --define "crystal_version $crystal_version" \
-    --define "gc_version $gc_version" \
-    --define "shards_version $shards_version"
+    --define "shards_version $shards_version" \
+    --define "release ${pkg_revision}%{?dist}"
 
 # put .rpm file in a scratch image for exporting
 FROM scratch AS pkgs

--- a/fedora/crystal.spec
+++ b/fedora/crystal.spec
@@ -13,7 +13,7 @@ BuildRequires:  zlib-devel
 Requires:       gcc pkgconfig pcre2-devel gc-devel
 Requires:       gmp-devel openssl-devel libxml2-devel
 Requires:       libyaml-devel zlib-devel
-Requires:       llvm-libs libffi
+Requires:       llvm-libs libffi git
 
 Source0: crystal.tar.gz
 Source1: shards.tar.gz

--- a/fedora/crystal.spec
+++ b/fedora/crystal.spec
@@ -6,12 +6,9 @@ License:        Apache-2.0
 URL:            https://crystal-lang.org
 Packager:       84codes <contact@84codes.com>
 
-%define _unpackaged_files_terminate_build 0
-
-BuildRequires:  git gcc gcc-c++ make gc-devel
-BuildRequires:  llvm-devel
-BuildRequires:  pcre2-devel libxml2-devel libyaml-devel libffi-devel
-BuildRequires:  openssl-devel zlib-devel gmp-devel autoconf automake libtool
+BuildRequires:  git gcc gcc-c++ make gc-devel llvm-devel
+BuildRequires:  pcre2-devel libyaml-devel libffi-devel
+BuildRequires:  zlib-devel
 
 Requires:       gcc pkgconfig pcre2-devel gc-devel
 Requires:       gmp-devel openssl-devel libxml2-devel
@@ -35,11 +32,11 @@ Crystal is a programming language with the following goals:
 %build
 # Build Crystal
 cd ../crystal-%{getenv:crystal_version}
-make crystal release=1 interpreter=1 LDFLAGS="%{build_ldflags}" CRYSTAL_CONFIG_LIBRARY_PATH=%{_libdir}/crystal
+make interpreter=1 LDFLAGS="%{build_ldflags}" CRYSTAL_CONFIG_LIBRARY_PATH=%{_libdir}/crystal
 
 # Build Shards
 cd ../shards-%{getenv:shards_version}
-make release=1 FLAGS="--link-flags=\"%{build_ldflags}\""
+make FLAGS="--link-flags=\"%{build_ldflags}\""
 
 %install
 # Install Crystal

--- a/fedora/crystal.spec
+++ b/fedora/crystal.spec
@@ -32,11 +32,11 @@ Crystal is a programming language with the following goals:
 %build
 # Build Crystal
 cd ../crystal-%{getenv:crystal_version}
-make interpreter=1 LDFLAGS="%{build_ldflags}" CRYSTAL_CONFIG_LIBRARY_PATH=%{_libdir}/crystal
+make release=1 interpreter=1 LDFLAGS="%{build_ldflags}" CRYSTAL_CONFIG_LIBRARY_PATH=%{_libdir}/crystal
 
 # Build Shards
 cd ../shards-%{getenv:shards_version}
-make FLAGS="--link-flags=\"%{build_ldflags}\""
+make release=1 FLAGS="--link-flags=\"%{build_ldflags}\""
 
 %install
 # Install Crystal

--- a/fedora/crystal.spec
+++ b/fedora/crystal.spec
@@ -35,11 +35,11 @@ Crystal is a programming language with the following goals:
 %build
 # Build Crystal
 cd ../crystal-%{getenv:crystal_version}
-make crystal interpreter=1 LDFLAGS="%{build_ldflags}" CRYSTAL_CONFIG_LIBRARY_PATH=%{_libdir}/crystal
+make crystal release=1 interpreter=1 LDFLAGS="%{build_ldflags}" CRYSTAL_CONFIG_LIBRARY_PATH=%{_libdir}/crystal
 
 # Build Shards
 cd ../shards-%{getenv:shards_version}
-make FLAGS="--link-flags=\"%{build_ldflags}\""
+make release=1 FLAGS="--link-flags=\"%{build_ldflags}\""
 
 %install
 # Install Crystal


### PR DESCRIPTION
Dont compile a static libgc, but use the shared libarary available in Fedora, it is compiled with the large config.

Don't download the sources in the RPM spec file, but in the docker container. Simplifies the spec quite a lot