### PR TITLE
Extract 'Upload to Packagecloud' step to reusable script

### DIFF
--- a/.github/scripts/upload-to-packagecloud.sh
+++ b/.github/scripts/upload-to-packagecloud.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Arguments:
+# $1 - Package type (deb or rpm)
+# $2 - Distribution information (distro/version)
+
+PACKAGECLOUD_TOKEN="$PACKAGECLOUD_TOKEN"
+PKG_TYPE="$1"
+DIST_INFO="$2"
+
+# Parse distribution name and version
+IFS='/' read -r DIST_NAME DIST_VERSION <<< "$DIST_INFO"
+
+# If distributions.json doesn't exist, download it
+if [ ! -f distributions.json ]; then
+  curl -fsSO -u "$PACKAGECLOUD_TOKEN:" https://packagecloud.io/api/v1/distributions.json
+fi
+
+# Get distribution ID
+if [ "$PKG_TYPE" == "deb" ]; then
+  DIST_ID=$(jq ".deb[] | select(.index_name == \"$DIST_NAME\").versions[] | select(.index_name == \"$DIST_VERSION\").id" distributions.json)
+else
+  DIST_ID=$(jq ".rpm[] | select(.index_name == \"$DIST_NAME\").versions[] | select(.index_name == \"$DIST_VERSION\").id" distributions.json)
+fi
+
+# Find and upload packages
+find pkgs -name "*.$PKG_TYPE" | xargs -I{} curl -fsSu "$PACKAGECLOUD_TOKEN:" \
+  -F "package[distro_version_id]=$DIST_ID" \
+  -F "package[package_file]=@{}" \
+  -XPOST https://packagecloud.io/api/v1/repos/84codes/crystal/packages.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,14 @@ jobs:
           name: crystal-static-pkgs
           path: pkgs
       - name: Upload deb package to Packagecloud
-        run: find pkgs -name "*.deb" -exec curl -fsSu "${{ secrets.packagecloud_token }}:" -F "package[distro_version_id]=35" -F "package[package_file]=@{}" -XPOST https://packagecloud.io/api/v1/repos/84codes/crystal/packages.json \;
+        run: .github/scripts/upload-to-packagecloud.sh deb any/any
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.packagecloud_token }}
         if: github.ref == 'refs/heads/main'
       - name: Upload RPM package to Packagecloud
-        run: find pkgs -name "*.rpm" -exec curl -fsSu "${{ secrets.packagecloud_token }}:" -F "package[distro_version_id]=227" -F "package[package_file]=@{}" -XPOST https://packagecloud.io/api/v1/repos/84codes/crystal/packages.json \;
+        run: .github/scripts/upload-to-packagecloud.sh rpm rpm_any/rpm_any
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.packagecloud_token }}
         if: github.ref == 'refs/heads/main'
 
   debian:
@@ -162,11 +166,9 @@ jobs:
             84codes/crystal:${{ env.crystal_version }}-${{ matrix.base_image }}-${{ matrix.version }}
             84codes/crystal:${{ env.crystal_version }}-${{ matrix.base_image }}-${{ matrix.codename }}
       - name: Upload to Packagecloud
-        run: |
-          set -euxo pipefail
-          curl -fsSO -u "${{ secrets.packagecloud_token }}:" https://packagecloud.io/api/v1/distributions.json
-          DIST_ID=$(jq ".deb[] | select(.index_name == \"${{ matrix.base_image }}\").versions[] | select(.index_name == \"${{ matrix.codename }}\").id" distributions.json)
-          find pkgs -name "*.deb" | xargs -I{} curl -fsSu "${{ secrets.packagecloud_token }}:" -F "package[distro_version_id]=$DIST_ID" -F "package[package_file]=@{}" -XPOST https://packagecloud.io/api/v1/repos/84codes/crystal/packages.json
+        run: .github/scripts/upload-to-packagecloud.sh deb "${{ matrix.base_image }}/${{ matrix.codename }}"
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.packagecloud_token }}
         if: ${{ github.ref == 'refs/heads/main' }}
 
   debian-static:
@@ -234,11 +236,9 @@ jobs:
           name: crystal-${{ matrix.base_image }}-${{ matrix.version }}-pkgs
           path: pkgs
       - name: Upload to Packagecloud
-        run: |
-          set -euxo pipefail
-          curl -fsSO -u "${{ secrets.packagecloud_token }}:" https://packagecloud.io/api/v1/distributions.json
-          DIST_ID=$(jq ".deb[] | select(.index_name == \"${{ matrix.base_image }}\").versions[] | select(.index_name == \"${{ matrix.codename }}\").id" distributions.json)
-          find pkgs -name "*.deb" | xargs -I{} curl -fsSu "${{ secrets.packagecloud_token }}:" -F "package[distro_version_id]=$DIST_ID" -F "package[package_file]=@{}" -XPOST https://packagecloud.io/api/v1/repos/84codes/crystal/packages.json
+        run: .github/scripts/upload-to-packagecloud.sh deb "${{ matrix.base_image }}/${{ matrix.codename }}"
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.packagecloud_token }}
         if: ${{ github.ref == 'refs/heads/main' }}
 
   fedora:
@@ -307,10 +307,9 @@ jobs:
           name: crystal-${{ matrix.base_image }}-${{ matrix.base_image_tag }}-pkgs
           path: pkgs
       - name: Upload to Packagecloud
-        run: |
-          set -euxo pipefail
-          DIST_ID=$(curl -fsSu "${{ secrets.packagecloud_token }}:" https://packagecloud.io/api/v1/distributions.json | jq ".rpm[] | select(.index_name == \"${{ matrix.base_image }}\").versions[] | select(.index_name == \"${{ matrix.base_image_tag }}\").id")
-          find pkgs -name "*.rpm" | xargs -I{} curl -fsSu "${{ secrets.packagecloud_token }}:" -F "package[distro_version_id]=$DIST_ID" -F "package[package_file]=@{}" -XPOST https://packagecloud.io/api/v1/repos/84codes/crystal/packages.json
+        run: .github/scripts/upload-to-packagecloud.sh rpm "${{ matrix.base_image }}/${{ matrix.base_image_tag }}"
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.packagecloud_token }}
         if: ${{ github.ref == 'refs/heads/main' }}
 
   centos:
@@ -377,8 +376,7 @@ jobs:
           name: crystal-centos-${{ matrix.base_image_tag }}-pkgs
           path: pkgs
       - name: Upload to Packagecloud
-        run: |
-          set -euxo pipefail
-          DIST_ID=$(curl -fsSu "${{ secrets.packagecloud_token }}:" https://packagecloud.io/api/v1/distributions.json | jq ".rpm[] | select(.index_name == \"el\").versions[] | select(.index_name == \"${{ matrix.el_version }}\").id")
-          find pkgs -name "*.rpm" | xargs -I{} curl -fsSu "${{ secrets.packagecloud_token }}:" -F "package[distro_version_id]=$DIST_ID" -F "package[package_file]=@{}" -XPOST https://packagecloud.io/api/v1/repos/84codes/crystal/packages.json
+        run: .github/scripts/upload-to-packagecloud.sh rpm "el/${{ matrix.el_version }}"
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.packagecloud_token }}
         if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Summary
- Create a centralized script for uploading packages to Packagecloud
- Update all workflow jobs to use this script for DEB and RPM packages
- Standardize input format to simplify maintenance

## Test plan
- Verify that packages are correctly uploaded to Packagecloud during workflow runs
- No functionality changes, just refactoring for better maintainability

🤖 Generated with [Claude Code](https://claude.ai/code)